### PR TITLE
Assisted injection into fragment

### DIFF
--- a/app/src/main/java/com/example/foody/recipe_details/presentation/RecipeDetailsFragment.kt
+++ b/app/src/main/java/com/example/foody/recipe_details/presentation/RecipeDetailsFragment.kt
@@ -6,11 +6,24 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
 import com.example.foody.recipe_details.presentation.ui.RecipeDetailsScreen
+import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.withCreationCallback
 
+@AndroidEntryPoint
 class RecipeDetailsFragment : Fragment() {
     private val args by navArgs<RecipeDetailsFragmentArgs>()
+
+    private val viewModel by viewModels<RecipeDetailsViewModel>(
+        extrasProducer = {
+            defaultViewModelCreationExtras
+                .withCreationCallback<RecipeDetailsViewModelFactory> { factory ->
+                    factory.create(args.recipeId)
+                }
+        }
+    )
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -18,7 +31,7 @@ class RecipeDetailsFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                RecipeDetailsScreen(args.recipeId)
+                RecipeDetailsScreen(viewModel)
             }
         }
     }

--- a/app/src/main/java/com/example/foody/recipe_details/presentation/RecipeDetailsViewModel.kt
+++ b/app/src/main/java/com/example/foody/recipe_details/presentation/RecipeDetailsViewModel.kt
@@ -5,23 +5,30 @@ import androidx.lifecycle.viewModelScope
 import com.example.foody.recipe_details.domain.RecipeDetailsSearchRepository
 import com.example.foody.recipe_details.presentation.model.RecipeDetailsState
 import com.example.foody.recipe_details.presentation.model.RecipeInfoState
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
-@HiltViewModel
-class RecipeDetailsViewModel @Inject constructor(
-    private val repository: RecipeDetailsSearchRepository,
-): ViewModel() {
+@HiltViewModel(assistedFactory = RecipeDetailsViewModelFactory::class)
+class RecipeDetailsViewModel @AssistedInject constructor(
+    @Assisted private val recipeId: String,
+    private val repository: RecipeDetailsSearchRepository
+) : ViewModel() {
 
     private val _state = MutableStateFlow(RecipeDetailsState.initialValue)
-    val state : StateFlow<RecipeDetailsState> = _state
+    val state: StateFlow<RecipeDetailsState> = _state
 
-    fun getRecipeDetails(recipeId: String) {
+    init {
+        getRecipeDetails()
+    }
+
+    private fun getRecipeDetails() {
         viewModelScope.launch(Dispatchers.IO) {
             withContext(Dispatchers.Main) {
                 _state.emit(_state.value.copy(detailsState = RecipeInfoState.RecipeInfoLoading))
@@ -39,4 +46,9 @@ class RecipeDetailsViewModel @Inject constructor(
             }
         }
     }
+}
+
+@AssistedFactory
+interface RecipeDetailsViewModelFactory {
+    fun create(recipeId: String): RecipeDetailsViewModel
 }

--- a/app/src/main/java/com/example/foody/recipe_details/presentation/ui/RecipeDetailsScreen.kt
+++ b/app/src/main/java/com/example/foody/recipe_details/presentation/ui/RecipeDetailsScreen.kt
@@ -1,16 +1,13 @@
 package com.example.foody.recipe_details.presentation.ui
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -26,7 +23,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -34,37 +30,33 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
-import com.example.foody.R
 import com.example.foody.recipe_details.presentation.RecipeDetailsViewModel
 import com.example.foody.recipe_details.presentation.model.RecipeInfoState
 import com.example.foody.shared.domain.model.Ingredient
 import com.example.foody.shared.domain.model.RecipeInfo
 import com.example.foody.shared.util.Constants
 
-// 1-st way to get recipeId from previous Fragment is via LaunchedEffect.
-// Because in here we only do this once
-// 2-nd way would be to pass a viewModel to Fragment directly
-// 3-rd way is via remember block for the same reason as in 1-st
-//    rememberSaveable { recipeViewModel.getRecipeDetails(recipeId) }
-// 4-th way would be via SavedStateHandle
-// 5-th way would be via Custom State Handler Implementation
+// Passing the recipeId (coming from previous screen) to ViewModel:
+// 1-st way is to set it (or use it) from here (Compose) via exposed public ViewModel function,
+//  but in a way which makes sure it is only called once (and not on every composition):
+//   - LaunchedEffect(key1 = recipeId) { recipeViewModel.getRecipeDetails(recipeId) }, or
+//   - rememberSaveable { recipeViewModel.getRecipeDetails(recipeId) }
+// 2-nd way is to inject the viewModel into Fragment and pass it to Compose function,
+//    and before passing it to set the recipeId (will be once),
+//    or to use assisted injection, since it is available from Fragment injection
+//    (assisted injection for Compose hiltViewModel function is also coming soon).
+// 3-rd - via SavedStateHandle (which is available to ViewModel, so doesn't need assisted inject)
+// 4-th - via custom state handler implementation - some singleton class
+//  with responsibility to hold the state until passed, and clear it once consumed.
 @Composable
 fun RecipeDetailsScreen(
-    recipeId: String,
-    recipeViewModel: RecipeDetailsViewModel = hiltViewModel()
+    recipeViewModel: RecipeDetailsViewModel //= hiltViewModel() assisted inject coming soon.
 ) {
-    // 1-st way
-    LaunchedEffect(key1 = recipeId) {
-        recipeViewModel.getRecipeDetails(recipeId)
-    }
-
     val state by recipeViewModel.state.collectAsState()
 
     when (val detailsState = state.detailsState) {

--- a/app/src/test/java/com/example/foody/recipe_details/presentation/RecipeDetailsViewModelTest.kt
+++ b/app/src/test/java/com/example/foody/recipe_details/presentation/RecipeDetailsViewModelTest.kt
@@ -35,13 +35,11 @@ class RecipeDetailsViewModelTest {
         Dispatchers.setMain(dispatcher)
 
         repoMock = mockk()
-
-        subject = RecipeDetailsViewModel(repoMock)
     }
 
     @Test
     fun `test Given we land on recipe detail screen, Then recipe details of that recipe are fetched`() {
-        subject.getRecipeDetails(testRecipeId)
+        createViewModel()
 
         coVerify { repoMock.getRecipeDetails(testRecipeId) }
     }
@@ -49,9 +47,9 @@ class RecipeDetailsViewModelTest {
 
     @Test
     fun `test Given we land on recipe detail screen, On a call to fetch recipe details, Then the loading is shown`() {
-        subject.getRecipeDetails(testRecipeId)
+        createViewModel()
 
-        assertEquals(RecipeInfoState.RecipeInfoLoading, subject.state.value.detailsState as RecipeInfoState.RecipeInfoLoading)
+        assertEquals(RecipeInfoState.RecipeInfoLoading, subject.state.value.detailsState)
     }
 
     @Test
@@ -59,7 +57,9 @@ class RecipeDetailsViewModelTest {
         val testRecipeInfo = getRecipeInfoTestData(testRecipeId)
         coEvery { repoMock.getRecipeDetails(testRecipeId) } returns testRecipeInfo
 
-        subject.getRecipeDetails(testRecipeId)
+        createViewModel()
+
+        assertEquals(RecipeInfoState.RecipeInfoLoading, subject.state.value.detailsState)
 
         coVerify { repoMock.getRecipeDetails(testRecipeId) }
 
@@ -70,7 +70,9 @@ class RecipeDetailsViewModelTest {
     fun `test Given we land on recipe detail screen, On recipe details fail to fetch, When error message is null, Then the generic error is shown`() {
         coEvery { repoMock.getRecipeDetails(testRecipeId) } throws IOException()
 
-        subject.getRecipeDetails(testRecipeId)
+        createViewModel()
+
+        assertEquals(RecipeInfoState.RecipeInfoLoading, subject.state.value.detailsState)
 
         coVerify { repoMock.getRecipeDetails(testRecipeId) }
 
@@ -82,7 +84,9 @@ class RecipeDetailsViewModelTest {
         val errorMessage = "error message"
         coEvery { repoMock.getRecipeDetails(testRecipeId) } throws IOException(errorMessage)
 
-        subject.getRecipeDetails(testRecipeId)
+        createViewModel()
+
+        assertEquals(RecipeInfoState.RecipeInfoLoading, subject.state.value.detailsState)
 
         coVerify { repoMock.getRecipeDetails(testRecipeId) }
 
@@ -92,5 +96,9 @@ class RecipeDetailsViewModelTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() {
+        subject = RecipeDetailsViewModel(testRecipeId, repoMock)
     }
 }


### PR DESCRIPTION
It seems that assisted injection is [now available with Hilt](https://dagger.dev/hilt/view-model.html) (second part of the page), just not yet available for injection into Compose (version of the `hiltViewModel` Compose function which enables it is not released yet). Thus we can use it, but need to inject the ViewModel into Fragment for now (and pass it to Compose function for now).

Hilt uses Dagger assisted injection, using annotations. How it works:

 - we need to add an interface annotated with `@AssistedFactory` annotation, which needs to have one function, which takes the pass-in (assisted) parameter and returns the ViewModel it creates as a type. But don't need to provide the implementation, as the annotation will be used to generate the implementation for us, so the generated class will be the one which ends up being used.
 - instead using `@Inject` annotation for ViewModel constructor, we need to use `@AssistedInject` (from Dagger API)
 - each (assisted) parameter which needs to be provided at the point of injection needs to be annotated with `@Assisted`
 - on the injection side, we need to use the `defaultViewModelCreationExtras.withCreationCallback` typed for the factory we want to be created. This will provide us the implementation of the factory we can use to give assisted input for ViewModel creation. It return `CreationExtras` which is one of the possible (optional) inputs (params) for the `viewModel` function, used to inject the ViewModel into fragment.

This Pull Request adds the implementation to:
 - refactor the ViewModel to be "assisted injected", also adding the factory
 - moves the ViewModel injection into the Fragment, to be able to inject it assisted, and then passes it to the Compose screen function.